### PR TITLE
Handle PlayerLoginEvent

### DIFF
--- a/src/cc/chaoticweg/mc/LeaveAMessage/LAMPlugin.java
+++ b/src/cc/chaoticweg/mc/LeaveAMessage/LAMPlugin.java
@@ -1,6 +1,7 @@
 package cc.chaoticweg.mc.LeaveAMessage;
 
 import cc.chaoticweg.mc.LeaveAMessage.command.LAMCommandExecutor;
+import cc.chaoticweg.mc.LeaveAMessage.event.LAMLoginEventListener;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -22,6 +23,7 @@ public class LAMPlugin extends JavaPlugin {
         // TODO
 
         this.getCommand("msg").setExecutor(LAMCommandExecutor.getInstance(this));
+        this.getServer().getPluginManager().registerEvents(LAMLoginEventListener.getInstance(this), this);
 
         log.info("Enabled.");
     }

--- a/src/cc/chaoticweg/mc/LeaveAMessage/event/LAMLoginEventListener.java
+++ b/src/cc/chaoticweg/mc/LeaveAMessage/event/LAMLoginEventListener.java
@@ -1,12 +1,45 @@
 package cc.chaoticweg.mc.LeaveAMessage.event;
 
+import cc.chaoticweg.mc.LeaveAMessage.LAMPlugin;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerLoginEvent;
+
+import java.util.logging.Logger;
 
 /**
  * Listens for {@link org.bukkit.event.Event}s.
  */
 public class LAMLoginEventListener implements Listener {
 
-    
+    private LAMPlugin main;
+    private Logger log;
+
+    private LAMLoginEventListener(LAMPlugin main) {
+        this.main = main;
+        this.log = main.getLogger();
+    }
+
+    @EventHandler
+    public void onPlayerLogin(PlayerLoginEvent event) {
+        Player player = event.getPlayer();
+        log.info("Player logged in: " + player.getDisplayName());
+
+        // TODO database handler: search for messages with this player as the recipient
+    }
+
+
+
+    /* Instance handling */
+
+    private static LAMLoginEventListener _instance = null;
+
+    public static LAMLoginEventListener getInstance(LAMPlugin main) {
+        if (_instance == null)
+            _instance = new LAMLoginEventListener(main);
+
+        return _instance;
+    }
 
 }

--- a/src/cc/chaoticweg/mc/LeaveAMessage/event/LAMLoginEventListener.java
+++ b/src/cc/chaoticweg/mc/LeaveAMessage/event/LAMLoginEventListener.java
@@ -1,0 +1,12 @@
+package cc.chaoticweg.mc.LeaveAMessage.event;
+
+import org.bukkit.event.Listener;
+
+/**
+ * Listens for {@link org.bukkit.event.Event}s.
+ */
+public class LAMLoginEventListener implements Listener {
+
+    
+
+}


### PR DESCRIPTION
Whenever a player logs in, LAM should check to see if there are any messages waiting for that player.
